### PR TITLE
Wetted restricts distance from

### DIFF
--- a/_src/app/habitat/Habitat.js
+++ b/_src/app/habitat/Habitat.js
@@ -561,7 +561,7 @@ define([
 
             let message = isValid ?
                 null :
-                'The distance from the starting bank cannot be greater than the wetted width.';
+                'The distance from the starting bank needs to be less than the wetted width.';
 
             return {
                 result: isValid,

--- a/_src/app/habitat/Habitat.js
+++ b/_src/app/habitat/Habitat.js
@@ -211,17 +211,8 @@ define([
                     }
                 }
             }];
+
             this.initGrid(columns);
-
-            this.own(
-                on(this.grid, 'keyup', () => {
-                    this.showValidation(this.wettedWidthTxt.valueAsNumber);
-                }),
-                on(this.grid, 'dgrid-datachange', () => {
-                    this.showValidation(this.wettedWidthTxt.valueAsNumber);
-                })
-            );
-
             this.addRow();
 
             // relayout grid once tab has been shown
@@ -231,7 +222,28 @@ define([
                 this.showValidation(this.wettedWidthTxt.valueAsNumber);
             }.bind(this));
 
+            this._trackStore();
+
             this.inherited(arguments);
+        },
+        _trackStore() {
+            // summary:
+            //      sets up the events to track the store
+            // param or return
+            console.info('app/habitat/Habitat:_trackStore', arguments);
+
+            if (this._storeEvent) {
+                this._storeEvent.remove();
+                this._storeEvent = null;
+            }
+
+            this._storeEvent = this.store.on('add, update, delete', () => {
+                this.showValidation(this.wettedWidthTxt.valueAsNumber);
+            });
+
+            this.own(
+                this._storeEvent
+            );
         },
         addRow: function () {
             // summary:
@@ -259,6 +271,8 @@ define([
                 if (inProgressData) {
                     if (inProgressData.gridData) {
                         this.setGridData(inProgressData.gridData);
+                        // setGridData creates a new store. Set up the events again
+                        this._trackStore();
                         this.grid.refresh();
                     }
 

--- a/_src/app/habitat/templates/Habitat.html
+++ b/_src/app/habitat/templates/Habitat.html
@@ -274,6 +274,8 @@
             </div>
         </div>
     </div>
+    <div class="hidden"
+          data-dojo-attach-point="validateMsg"></div>
     <div class="row">
         <div class="col-md-12">
             <div data-dojo-attach-point="gridDiv"></div>

--- a/_src/app/habitat/templates/Habitat.html
+++ b/_src/app/habitat/templates/Habitat.html
@@ -250,6 +250,7 @@
                 <label class="control-label">Wetted Width (m)</label>
                 <input type="number"
                     data-dojo-attach-point="wettedWidthTxt"
+                    data-dojo-attach-event="change:onWidthChange"
                     step="0.01"
                     min="0"
                     max="1000"
@@ -262,8 +263,7 @@
                 <select data-dojo-attach-point="startingBank" class="form-control"></select>
             </div>
         </div>
-        <div class="col-md-3">
-            <br>
+        <div class="col-md-3" style="margin-top:25px">
             <div class="btn-group">
                 <a class="btn btn-danger"
                     data-dojo-attach-point="deleteRowBtn"

--- a/_src/app/tests/spec/SpecHabitat.js
+++ b/_src/app/tests/spec/SpecHabitat.js
@@ -226,7 +226,7 @@ require([
                 const valid = testWidget._validateWidth(wettedWidth);
 
                 expect(valid.result).toBe(false);
-                expect(valid.message).toContain('cannot be greater than');
+                expect(valid.message).toContain('less than');
             });
         });
 

--- a/_src/app/tests/spec/SpecHabitat.js
+++ b/_src/app/tests/spec/SpecHabitat.js
@@ -170,6 +170,66 @@ require([
             });
         });
 
+        describe('wetted width and start distance', () => {
+            it('is valid with undefined wetted width value', () => {
+                let wettedWidth;
+
+                testWidget.store.data[0] = { DEPTH: 1, DISTANCE_START: null };
+                testWidget.store.data[1] = { DEPTH: 10, DISTANCE_START: 9 };
+
+                const valid = testWidget._validateWidth(wettedWidth);
+
+                expect(valid.result).toBe(true);
+                expect(valid.message).toContain('does not have a value');
+            });
+            it('is valid with null wetted width value', () => {
+                const wettedWidth = null;
+
+                testWidget.store.data[0] = { DEPTH: 1, DISTANCE_START: null };
+                testWidget.store.data[1] = { DEPTH: 10, DISTANCE_START: 9 };
+
+                const valid = testWidget._validateWidth(wettedWidth);
+
+                expect(valid.result).toBe(true);
+                expect(valid.message).toContain('does not have a value');
+            });
+            it('is valid when start distances are empty', () => {
+                const wettedWidth = 10;
+
+                testWidget.store.data[0] = { DEPTH: 1, DISTANCE_START: null };
+                testWidget.store.data[1] = { DEPTH: 10, DISTANCE_START: null };
+
+                const valid = testWidget._validateWidth(wettedWidth);
+
+                expect(valid.result).toBe(true);
+                expect(valid.message).toBeNull();
+            });
+            it('is valid when wetted width value is greater than all start distances', () => {
+                const wettedWidth = 10;
+
+                testWidget.store.data[0] = { DEPTH: 1, DISTANCE_START: null };
+                testWidget.store.data[1] = { DEPTH: 10, DISTANCE_START: 9 };
+                testWidget.store.data[2] = { DEPTH: 10, DISTANCE_START: 3.01 };
+
+                const valid = testWidget._validateWidth(wettedWidth);
+
+                expect(valid.result).toBe(true);
+                expect(valid.message).toBeNull();
+            });
+            it('is not valid when wetted width value is smaller than any start distances', () => {
+                const wettedWidth = 10;
+
+                testWidget.store.data[0] = { DEPTH: 1, DISTANCE_START: 11 };
+                testWidget.store.data[1] = { DEPTH: 10, DISTANCE_START: 9 };
+                testWidget.store.data[2] = { DEPTH: 10, DISTANCE_START: 3.01 };
+
+                const valid = testWidget._validateWidth(wettedWidth);
+
+                expect(valid.result).toBe(false);
+                expect(valid.message).toContain('cannot be greater than');
+            });
+        });
+
         describe('onRemoveTransect', function () {
             it('removes the transect object', function () {
                 testWidget.gridTab.addTab();


### PR DESCRIPTION
This assumes that the wetted width > distance from start

Warnings are shown when wetted width is empty. 
Errors are shown when wetted width <= distance from start

This is not included in the submission report checks. That will be a part of #69 

closes #146 
