### PR TITLE
Allow easier recording of duplicate fish rows in Catch tab

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,8 @@
     "globals": {
         "L": false,
         "Promise": true
+    },
+    "env": {
+        "es6": true
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/agrc/electrofishing.svg?branch=master)](https://travis-ci.org/agrc/electrofishing)
+[![Build Status](https://travis-ci.com/agrc/electrofishing.svg?branch=master)](https://travis-ci.com/agrc/electrofishing)
 
 # electro fishing
 Application for recording electrofishing surveys. Built for DWR.

--- a/_src/app/_GridMixin.js
+++ b/_src/app/_GridMixin.js
@@ -143,9 +143,7 @@ define([
             var modifierKeys = [
                 keys.TAB,
                 keys.LEFT_ARROW,
-                keys.UP_ARROW,
-                keys.RIGHT_ARROW,
-                keys.DOWN_ARROW
+                keys.RIGHT_ARROW
             ];
 
             var advance = function () {
@@ -189,12 +187,6 @@ define([
                         break;
                     case keys.RIGHT_ARROW:
                         advance();
-                        break;
-                    case keys.UP_ARROW:
-                        Keyboard.moveFocusUp.call(that.grid, e);
-                        break;
-                    case keys.DOWN_ARROW:
-                        Keyboard.moveFocusDown.call(that.grid, e);
                         break;
                     default:
                         break;

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -80,7 +80,7 @@ define([
         //      The number of fields to skip when you tab at the end of the row
         //      This is to skip over the hidden fields
         //      required for _GridMixin
-        skipNumber: 6,
+        skipNumber: 7,
 
         // lastColumn: String
         //      required for _GridMixin

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -66,6 +66,7 @@ define([
     papaparse
 ) {
     const FN = config.fieldNames.fish;
+    const COUNT = 'COUNT';
 
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _GridMixin], {
         widgetsInTemplate: true,
@@ -199,6 +200,19 @@ define([
                             min: 0
                         }
                     }
+                }, {
+                    autoSave: true,
+                    label: 'Count',
+                    field: COUNT,
+                    editor: this.NewNumberSpinner,
+                    sortable: false,
+                    autoSelect: true,
+                    editOn: 'focus',
+                    editorArgs: {
+                        constraints: {
+                            min: 1
+                        }
+                    }
                 }
             ];
 
@@ -299,6 +313,7 @@ define([
                 [fn.LENGTH_TYPE]: lastLengthType,
                 [fn.LENGTH]: null,
                 [fn.WEIGHT]: null,
+                [COUNT]: 1,
                 [fn.NOTES]: ''
             };
 

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -483,7 +483,7 @@ define([
 
             var row = this.getSelectedRow();
 
-            if (row) {
+            if (row && row.data[this.COUNT] === 1) {
                 this.moreInfoDialog.show(row.data[config.fieldNames.fish.FISH_ID],
                     evt.target.dataset.tab);
             }

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -520,8 +520,17 @@ define([
                 if (count === 1) {
                     expandedRows.push(nextRow);
                 } else {
+                    const weight = nextRow[FN.WEIGHT];
+                    let averageWeight;
+                    if (weight) {
+                        averageWeight = nextRow[FN.WEIGHT] / count;
+                    }
                     while (count > 0) {
                         nextRow[FN.FISH_ID] = this.getNewFishId();
+
+                        if (weight) {
+                            nextRow[FN.WEIGHT] = averageWeight;
+                        }
 
                         expandedRows.push(lang.clone(nextRow));
 

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -473,7 +473,9 @@ define([
             //      description
             console.log('app/catch/Catch:onBatchToggle', arguments);
 
-            this.batchWeightTxt.focus();
+            window.setTimeout(() => {
+                this.batchWeightTxt.focus();
+            }, 100);
         },
         moreInfo: function (evt) {
             // summary:

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -443,7 +443,7 @@ define([
 
             var affectedRows = [];
             var item = data.pop();
-            while (item && !item[fn.WEIGHT]) {
+            while (item && item[this.COUNT] === 1 && !item[fn.WEIGHT]) {
                 affectedRows.push(item);
                 item = data.pop();
             }

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -66,7 +66,6 @@ define([
     papaparse
 ) {
     const FN = config.fieldNames.fish;
-    const COUNT = 'COUNT';
 
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _GridMixin], {
         widgetsInTemplate: true,
@@ -116,6 +115,9 @@ define([
         //     gridData: object[]
         // }
 
+        // COUNT: string
+        //      name of the Count field in the grid
+        COUNT: 'COUNT',
 
         constructor: function () {
             // summary:
@@ -203,7 +205,7 @@ define([
                 }, {
                     autoSave: true,
                     label: 'Count',
-                    field: COUNT,
+                    field: this.COUNT,
                     editor: this.NewNumberSpinner,
                     sortable: false,
                     autoSelect: true,
@@ -305,7 +307,7 @@ define([
                 lastLengthType = lastRow[fn.LENGTH_TYPE];
             }
             var row = {
-                [fn.FISH_ID]: '{' + generateRandomUuid() + '}',
+                [fn.FISH_ID]: this.getNewFishId(),
                 [fn.EVENT_ID]: config.eventId,
                 [fn.PASS_NUM]: this.gridTab.currentTab,
                 [fn.CATCH_ID]: catchId,
@@ -313,7 +315,7 @@ define([
                 [fn.LENGTH_TYPE]: lastLengthType,
                 [fn.LENGTH]: null,
                 [fn.WEIGHT]: null,
-                [COUNT]: 1,
+                [this.COUNT]: 1,
                 [fn.NOTES]: ''
             };
 
@@ -324,6 +326,14 @@ define([
             this.grid.focus(this.grid.cell(row[fn.FISH_ID], '5'));
 
             return row[fn.FISH_ID];
+        },
+        getNewFishId() {
+            // summary
+            //      returns a new fish id string
+            // returns: string
+            console.log('app/catch/Catch:getNewFishId', arguments);
+
+            return '{' + generateRandomUuid() + '}';
         },
         onAddPass: function (event) {
             // summary:
@@ -504,7 +514,23 @@ define([
             //      packages up the grid data as a record set
             console.log('app/catch/Catch:getData', arguments);
 
-            return this.getGridData();
+            return this.getGridData().reduce((expandedRows, nextRow) => {
+                let count = nextRow[this.COUNT];
+                delete nextRow[this.COUNT];
+                if (count === 1) {
+                    expandedRows.push(nextRow);
+                } else {
+                    while (count > 0) {
+                        nextRow[FN.FISH_ID] = this.getNewFishId();
+
+                        expandedRows.push(lang.clone(nextRow));
+
+                        count = count - 1;
+                    }
+                }
+
+                return expandedRows;
+            }, []);
         },
         _setSelectedRowAttr: function (row) {
             // summary:

--- a/_src/app/location/templates/Location.html
+++ b/_src/app/location/templates/Location.html
@@ -2,7 +2,7 @@
     <h4>Water Body</h4>
     <div data-dojo-attach-point="verifyMap" data-dojo-type="app/location/VerifyMap" data-dojo-props="isMainMap:true" class="v-map"></div>
     <div data-dojo-type="app/location/Station" data-dojo-attach-point="station"></div>
-    <h4>Stream Reach</h4>
+    <h4>Stream Reach <span class="text-danger required">*</span></h4>
     <ul class="nav nav-pills">
         <li class="active">
             <a id="startEndTab" href="#loc_startend" data-toggle="tab">Start | End</a>

--- a/_src/app/location/templates/Station.html
+++ b/_src/app/location/templates/Station.html
@@ -1,9 +1,9 @@
 <div>
-    <h4 class='heading'>Station</h4>
+    <h4 class='heading'>Station <span class="text-danger required">*</span></h4>
     <p class="help-block">Select a station by clicking on the map above.</p>
     <div class="form-inline">
         <div class="form-group">
-            <span class="text-danger required">*</span><input type='text' disabled data-dojo-attach-point='stationTxt' class='form-control'>
+            <input type='text' disabled data-dojo-attach-point='stationTxt' class='form-control'>
         </div>
         <a class="btn btn-default" data-dojo-attach-point='newStationBtn' data-toggle='modal' href='#stationModal'>
             <span class='glyphicon glyphicon-plus'></span>

--- a/_src/app/resources/App.styl
+++ b/_src/app/resources/App.styl
@@ -65,7 +65,6 @@ footer {
 }
 
 .required {
-    font-size: 200%
     font-weight: 900
     line-height: 0
 }

--- a/_src/app/tests/spec/SpecCatch.js
+++ b/_src/app/tests/spec/SpecCatch.js
@@ -100,7 +100,6 @@ require([
 
                 var addedRow = testWidget.store.data[testWidget.store.data.length - 1];
 
-                console.log(testWidget.store.data);
                 expect(addedRow[fn.CATCH_ID]).toBe(3);
             });
             it('remembers the species code and length type', function () {
@@ -288,6 +287,27 @@ require([
 
                 expect(data[0][config.fieldNames.fish.WEIGHT]).toBe(null);
                 expect(data[1][config.fieldNames.fish.WEIGHT]).toBe(5);
+                expect(data[2][config.fieldNames.fish.WEIGHT]).toBe(4.5);
+                expect(data[3][config.fieldNames.fish.WEIGHT]).toBe(4.5);
+            });
+            it('it does not affect rows with count > 1', function () {
+                testWidget.addRow({
+                    [testWidget.COUNT]: 2
+                });
+                testWidget.addRow();
+                testWidget.addRow();
+
+                testWidget.batchWeightTxt.value = 9;
+
+                var data = testWidget.store.data;
+                data.forEach(function (d) {
+                    d[config.fieldNames.fish.SPECIES_CODE] = 'a';
+                });
+
+                testWidget.batch();
+
+                expect(data[0][config.fieldNames.fish.WEIGHT]).toBe(null);
+                expect(data[1][config.fieldNames.fish.WEIGHT]).toBe(null);
                 expect(data[2][config.fieldNames.fish.WEIGHT]).toBe(4.5);
                 expect(data[3][config.fieldNames.fish.WEIGHT]).toBe(4.5);
             });

--- a/_src/app/tests/spec/SpecCatch.js
+++ b/_src/app/tests/spec/SpecCatch.js
@@ -391,5 +391,48 @@ require([
                 expect(testWidget.store.fetchSync().length).toBe(1);
             });
         });
+
+        describe('getData', function () {
+            it('duplicates rows with count > 1', function () {
+                const rows = [
+                    // fish id, count
+                    [1, 1],
+                    [2, 1],
+                    [3, 5],
+                    [4, 1]
+                ];
+
+                rows.forEach(row => {
+                    const [fishId, count] = row;
+                    testWidget.store.addSync({
+                        [FN.FISH_ID]: fishId,
+                        [FN.EVENT_ID]: 'blah',
+                        [FN.PASS_NUM]: 1,
+                        [FN.CATCH_ID]: 'blah',
+                        [FN.SPECIES_CODE]: 'BT',
+                        [FN.LENGTH_TYPE]: null,
+                        [FN.LENGTH]: null,
+                        [FN.WEIGHT]: null,
+                        [testWidget.COUNT]: count,
+                        [FN.NOTES]: ''
+                    });
+                });
+
+                const submissionRows = testWidget.getData();
+                console.log(submissionRows);
+
+                expect(submissionRows.length).toBe(9);
+
+                // make sure that unique fish ids were created
+                const uniqueIds = submissionRows.reduce((set, nextRow) => {
+                    set.add(nextRow[FN.FISH_ID]);
+
+                    return set;
+                }, new Set());
+                expect(uniqueIds.size).toBe(9);
+
+                expect(submissionRows[0][testWidget.COUNT]).toBeUndefined();
+            });
+        });
     });
 });

--- a/_src/app/tests/spec/SpecCatch.js
+++ b/_src/app/tests/spec/SpecCatch.js
@@ -419,7 +419,6 @@ require([
                 });
 
                 const submissionRows = testWidget.getData();
-                console.log(submissionRows);
 
                 expect(submissionRows.length).toBe(9);
 
@@ -432,6 +431,40 @@ require([
                 expect(uniqueIds.size).toBe(9);
 
                 expect(submissionRows[0][testWidget.COUNT]).toBeUndefined();
+            });
+            it('batch weights for duplicate rows', function () {
+                const averageCatchID = 'averageCatch';
+                const rows = [
+                    // fish id, weight, count, catchID
+                    [1, 1, 1, 'blah'],
+                    [2, 2, 1, 'blah'],
+                    [3, 10, 3, averageCatchID],
+                    [4, 4, 1, 'blah']
+                ];
+
+                rows.forEach(row => {
+                    const [fishId, weight, count, catchID] = row;
+                    testWidget.store.addSync({
+                        [FN.FISH_ID]: fishId,
+                        [FN.EVENT_ID]: 'blah',
+                        [FN.PASS_NUM]: 1,
+                        [FN.CATCH_ID]: catchID,
+                        [FN.SPECIES_CODE]: 'BT',
+                        [FN.LENGTH_TYPE]: null,
+                        [FN.LENGTH]: null,
+                        [FN.WEIGHT]: weight,
+                        [testWidget.COUNT]: count,
+                        [FN.NOTES]: ''
+                    });
+                });
+
+                const submissionRows = testWidget.getData();
+
+                submissionRows.forEach(row => {
+                    if (row[FN.CATCH_ID] === averageCatchID) {
+                        expect(row[FN.WEIGHT]).toBeCloseTo(3.33, 2);
+                    }
+                });
             });
         });
     });

--- a/_src/app/tests/spec/Spec_GridTab.js
+++ b/_src/app/tests/spec/Spec_GridTab.js
@@ -1,9 +1,11 @@
 require([
+    'app/config',
     'app/GridTab',
 
     'dojo/dom-construct',
     'dojo/query'
 ], function (
+    config,
     GridTab,
 
     domConstruct,


### PR DESCRIPTION
This PR adds an additional field to the catch grid called "Count". This allows the user to enter a single row for duplicate fish. Behind the scenes, the code duplicates the data sent to the server and averages the weight between the rows if it's populated populated.

It also updated the batch tool to be aware of the count field and to not mess with rows when the count is more than 1.

Closes #49 
