### PR TITLE
stop isTrusted from being added to row

### DIFF
--- a/_src/app/_GridMixin.js
+++ b/_src/app/_GridMixin.js
@@ -267,16 +267,7 @@ define([
                 }
 
                 data.forEach(function removeIgnoreFields(d) {
-                    let ignoreColumn = this.ignoreColumn;
-                    if (!Array.isArray(this.ignoreColumn)) {
-                        ignoreColumn = [this.ignoreColumn];
-                    }
-
-                    ignoreColumn.forEach(column => {
-                        if (d[column]) {
-                            delete d[column];
-                        }
-                    });
+                    delete d[this.ignoreColumn];
                 }, this);
 
                 return data;

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -130,7 +130,7 @@ define([
             this.lastColumn = fn.WEIGHT;
             this.firstColumn = fn.SPECIES_CODE;
             this.idProperty = fn.FISH_ID;
-            this.ignoreColumn = [config.fieldNames.MOREINFO, 'isTrusted'];
+            this.ignoreColumn = config.fieldNames.MOREINFO;
         },
         postCreate: function () {
             // summary:

--- a/_src/app/catch/Catch.js
+++ b/_src/app/catch/Catch.js
@@ -285,7 +285,7 @@ define([
                 on(this.batchWeightTxt, 'keyup, change', lang.hitch(this, 'validateBatchForm'))
             );
         },
-        addRow: function (overrides = {}) {
+        addRow: function (event, overrides = {}) {
             // summary
             //      Adds a new empty row to the grid with the appropriate
             //      pass number and a new guid
@@ -607,7 +607,7 @@ define([
                 this.store.removeSync(lastRow[this.idProperty]);
             }
 
-            parseResults.data.forEach(data => this.addRow(data));
+            parseResults.data.forEach(data => this.addRow(null, data));
 
             this.grid.refresh();
         },

--- a/_src/app/tests/spec/SpecCatch.js
+++ b/_src/app/tests/spec/SpecCatch.js
@@ -114,11 +114,11 @@ require([
                 expect(newObject[config.fieldNames.fish.SPECIES_CODE]).toBe(species);
                 expect(newObject[config.fieldNames.fish.LENGTH_TYPE]).toBe(lengthType);
             });
-            it('it accepts optional values to populate the row with', function () {
+            it('accepts optional values to populate the row with', function () {
                 const species = 'BS';
                 const num = '1';
                 const lenType = 'STD';
-                const id = testWidget.addRow({
+                const id = testWidget.addRow(null, {
                     [FN.SPECIES_CODE]: species,
                     [FN.LENGTH_TYPE]: lenType,
                     [FN.LENGTH]: num,
@@ -290,8 +290,8 @@ require([
                 expect(data[2][config.fieldNames.fish.WEIGHT]).toBe(4.5);
                 expect(data[3][config.fieldNames.fish.WEIGHT]).toBe(4.5);
             });
-            it('it does not affect rows with count > 1', function () {
-                testWidget.addRow({
+            it('does not affect rows with count > 1', function () {
+                testWidget.addRow(null, {
                     [testWidget.COUNT]: 2
                 });
                 testWidget.addRow();


### PR DESCRIPTION
addRow was being called with a click event which passed an event to it's default parameter.

object.assign was mixing the event with the row and isTrusted must be the only non has own property to get added. ¯\_(ツ)_/¯

This was unexpected since you probably only thought row data should be sent to the function. Typescript would have caught this bug. lol

I added another parameter to capture and ignore the click event and passed the data as the second optional parameter to match expectations.

I updated the gp tool and published it. These changes should be deployed before you email the clients.