### PR TITLE
Prepopulate equipment

### DIFF
--- a/_src/app/_InProgressCacheMixin.js
+++ b/_src/app/_InProgressCacheMixin.js
@@ -67,31 +67,21 @@ define([
 
             this.inherited(arguments);
         },
-        hydrateWithInProgressData: function () {
+        hydrateWithInProgressData: function (data) {
             // summary:
             //      populates the controls with in progress cached data
             console.log('app/_InProgressCacheMixin:hydrateWithInProgressData', arguments);
 
-            var that = this;
+            if (data) {
+                return new Promise((resolve) => {
+                    this._setFields(data);
+                    resolve(data);
+                });
+            }
 
-            return localforage.getItem(`${this.cachePrefix}_${this.cacheId}`).then(function (inProgressData) {
+            return localforage.getItem(`${this.cachePrefix}_${this.cacheId}`).then((inProgressData) => {
                 if (inProgressData) {
-                    that.inputs.forEach(function (node) {
-                        if (node.dataset.dojoAttachPoint in inProgressData) {
-                            if (node.tagName === 'SELECT' && node.children.length === 0) {
-                                node.dataset[config.tempValueKey] = inProgressData[node.dataset.dojoAttachPoint];
-                            } else {
-                                node.value = inProgressData[node.dataset.dojoAttachPoint];
-                            }
-
-                            // fire onchange for inputs involved with NumericInputValidator
-                            on.emit(node, 'change', {bubbles: false});
-
-                            if (node.tagName === 'SELECT') {
-                                $(node).combobox('refresh');
-                            }
-                        }
-                    });
+                    this._setFields(inProgressData);
                 }
 
                 return inProgressData;
@@ -126,6 +116,29 @@ define([
             console.log('app/_InProgressCacheMixin:getAdditionalCacheData', arguments);
 
             return {};
+        },
+        _setFields(data) {
+            // summary:
+            //      description
+            // param or return
+            console.info('app/_InProgressCacheMixin:_setFields', arguments);
+
+            this.inputs.forEach((node) => {
+                if (node.dataset.dojoAttachPoint in data) {
+                    if (node.tagName === 'SELECT' && node.children.length === 0) {
+                        node.dataset[config.tempValueKey] = data[node.dataset.dojoAttachPoint];
+                    } else {
+                        node.value = data[node.dataset.dojoAttachPoint];
+                    }
+
+                    // fire onchange for inputs involved with NumericInputValidator
+                    on.emit(node, 'change', {bubbles: false});
+
+                    if (node.tagName === 'SELECT') {
+                        $(node).combobox('refresh');
+                    }
+                }
+            });
         }
     });
 });

--- a/_src/app/_InProgressCacheMixin.js
+++ b/_src/app/_InProgressCacheMixin.js
@@ -40,7 +40,7 @@ define([
             //      set up
             console.log('app/_InProgressCacheMixin:postCreate', arguments);
 
-            if (!this.cacheId || this.cacheId.length === 0) {
+            if (this.cacheId === null || this.cacheId === undefined) {
                 throw new Error(this.missingCacheIdError);
             }
 
@@ -74,7 +74,7 @@ define([
 
             var that = this;
 
-            return localforage.getItem(this.cacheId).then(function (inProgressData) {
+            return localforage.getItem(`${this.cachePrefix}_${this.cacheId}`).then(function (inProgressData) {
                 if (inProgressData) {
                     that.inputs.forEach(function (node) {
                         if (node.dataset.dojoAttachPoint in inProgressData) {
@@ -109,7 +109,7 @@ define([
 
             data = lang.mixin(data, this.getAdditionalCacheData());
 
-            return localforage.setItem(this.cacheId, data)
+            return localforage.setItem(`${this.cachePrefix}_${this.cacheId}`, data)
                 .then(null, lang.partial(lang.hitch(this, 'onError'), 'caching data.'));
         },
         onError: function (error, message) {

--- a/_src/app/_MultipleWidgetsWithAddBtnMixin.js
+++ b/_src/app/_MultipleWidgetsWithAddBtnMixin.js
@@ -48,16 +48,21 @@ define([
 
             this.addAddBtnWidget();
         },
-        addAddBtnWidget: function () {
+        addAddBtnWidget: function (id) {
             // summary:
             //      Fires when the add button is pressed on the _addBtn widget
             console.log('app/_MultipleWidgetsWithAddBtnMixin:addAddBtnWidget', arguments);
+
+            if (id === null || id === undefined) {
+                id = this.equipmentCounter;
+                this.equipmentCounter += 1;
+            }
 
             var widget = new this.AddBtnWidgetClass(
                 {
                     container: this,
                     // for local caching of Method only, doesn't hurt moreinfodialog
-                    cacheId: this.cacheId + '_' + this.addBtnWidgets.length
+                    cacheId: id || this.equipmentCounter
                 },
                 domConstruct.create('div', {}, this.addBtnWidgetsContainer)
             );

--- a/_src/app/_MultipleWidgetsWithAddBtnMixin.js
+++ b/_src/app/_MultipleWidgetsWithAddBtnMixin.js
@@ -54,15 +54,15 @@ define([
             console.log('app/_MultipleWidgetsWithAddBtnMixin:addAddBtnWidget', arguments);
 
             if (id === null || id === undefined) {
-                id = this.equipmentCounter;
-                this.equipmentCounter += 1;
+                id = this.widgetCounter;
+                this.widgetCounter += 1;
             }
 
             var widget = new this.AddBtnWidgetClass(
                 {
                     container: this,
                     // for local caching of Method only, doesn't hurt moreinfodialog
-                    cacheId: id || this.equipmentCounter
+                    cacheId: id || this.widgetCounter
                 },
                 domConstruct.create('div', {}, this.addBtnWidgetsContainer)
             );

--- a/_src/app/method/Equipment.js
+++ b/_src/app/method/Equipment.js
@@ -98,6 +98,9 @@ define([
         //      set by _MultipleWidgetsWithAddBtnMixin
         cacheId: null,
 
+        // cachePrefix: String
+        cachePrefix: 'app/method',
+
 
         constructor: function () {
             // summary:
@@ -412,7 +415,7 @@ define([
             //      remove cached in progress data item
             console.log('app/method/Equipment:onRemove', arguments);
 
-            localforage.removeItem(this.cacheId);
+            localforage.removeItem(`${this.cachePrefix}_${this.cacheId}`);
 
             this.inherited(arguments);
         },

--- a/_src/app/method/Method.js
+++ b/_src/app/method/Method.js
@@ -41,9 +41,9 @@ define([
         //      the equipment ids for linking to local storage
         equipmentIds: null,
 
-        // equipmentCounter: unique number for counting equipment widgets
+        // widgetCounter: unique number for counting equipment widgets
         //      used to build cacheId's in _MultipleWidgetsWithAddBtnMixin
-        equipmentCounter: 2,
+        widgetCounter: 2,
 
         constructor: function () {
             // summary:
@@ -83,7 +83,7 @@ define([
             this.promise = localforage.getItem(this.cacheId).then((ids) => {
                 if (ids && ids.length > 0) {
                     this.equipmentIds = ids;
-                    this.equipmentCounter = Math.max(...this.equipmentIds) + 1;
+                    this.widgetCounter = Math.max(...this.equipmentIds) + 1;
                     this.createEquipments(this.equipmentIds);
                 } else {
                     this.equipmentIds = [1];

--- a/_src/app/method/templates/Equipment.html
+++ b/_src/app/method/templates/Equipment.html
@@ -19,7 +19,7 @@
                 class="form-control">
             </select>
         </div>
-        <div class="form-group col-md-3">
+        <div class="form-group col-md-3 hidden">
             <label>Array Type</label>
             <select data-dojo-attach-point="arrayTypeSelect" class="form-control"></select>
         </div>
@@ -31,7 +31,7 @@
                 min="1"
                 max="20">
         </div>
-        <div class="form-group col-md-2">
+        <div class="form-group col-md-2 hidden">
             <label>Cathode Type</label>
             <select data-dojo-attach-point="cathodeTypeSelect" class="form-control"></select>
         </div>

--- a/_src/app/tests/spec/SpecMethod.js
+++ b/_src/app/tests/spec/SpecMethod.js
@@ -26,13 +26,16 @@ require([
 
         describe('initChildWidgets', function () {
             it('creates multiple existing widgets if there is cached in progress data', function (done) {
-                localforage.setItem(Method.prototype.cacheId, [1, 2, 3]).then(function () {
-                    testWidget.addBtnWidgets = [];
+                console.warn(`setting ${Method.prototype.cacheId} to [1, 2, 3]`);
+                localforage.clear().then(() => {
+                    localforage.setItem(Method.prototype.cacheId, [1, 2, 3]).then(function () {
+                        testWidget.addBtnWidgets = [];
 
-                    testWidget.initChildWidgets().then(function () {
-                        expect(testWidget.addBtnWidgets.length).toBe(3);
+                        testWidget.initChildWidgets().then(function () {
+                            expect(testWidget.addBtnWidgets.length).toBe(3);
 
-                        done();
+                            done();
+                        });
                     });
                 });
             });

--- a/_src/app/tests/spec/SpecMethod.js
+++ b/_src/app/tests/spec/SpecMethod.js
@@ -26,7 +26,7 @@ require([
 
         describe('initChildWidgets', function () {
             it('creates multiple existing widgets if there is cached in progress data', function (done) {
-                localforage.setItem(Method.prototype.cacheId, 3).then(function () {
+                localforage.setItem(Method.prototype.cacheId, [1, 2, 3]).then(function () {
                     testWidget.addBtnWidgets = [];
 
                     testWidget.initChildWidgets().then(function () {

--- a/_src/app/tests/spec/Spec_InProgressCacheMixin.js
+++ b/_src/app/tests/spec/Spec_InProgressCacheMixin.js
@@ -42,6 +42,7 @@ require([
             localforage.clear().then(function () {
                 testWidget = new TestWidget({
                     cacheId: 'TestWidget',
+                    cachePrefix: 'jasmine',
                     template: testTemplate
                 }, domConstruct.create('div', null, document.body));
                 testWidget.startup();
@@ -61,7 +62,7 @@ require([
             testWidget.select.value = selectValue;
 
             testWidget.cacheInProgressData().then(function () {
-                localforage.getItem(testWidget.cacheId).then(function (value) {
+                localforage.getItem(`${testWidget.cachePrefix}_${testWidget.cacheId}`).then(function (value) {
                     expect(value.someBox).toBe(someValue);
                     expect(value.anotherBox).toBe(anotherValue);
                     expect(value.textArea).toBe(textAreaValue);
@@ -80,6 +81,7 @@ require([
         });
         it('populates values if there is existing cached data', function (done) {
             var cacheId = 'testId';
+            var cachePrefix = 'jasmine';
             var testWidget2;
             var assert = function () {
                 expect(testWidget2.someBox.value).toBe(someValue);
@@ -93,13 +95,16 @@ require([
                 done();
             };
             var createWidget = function () {
-                testWidget2 = new TestWidget({cacheId: cacheId}, domConstruct.create('div', null, document.body));
+                testWidget2 = new TestWidget({
+                    cacheId,
+                    cachePrefix
+                }, domConstruct.create('div', null, document.body));
                 testWidget2.startup();
 
                 testWidget2.hydrateWithInProgressData().then(assert, onError);
             };
 
-            localforage.setItem(cacheId, {
+            localforage.setItem(`${cachePrefix}_${cacheId}`, {
                 someBox: someValue,
                 anotherBox: anotherValue,
                 textArea: textAreaValue,


### PR DESCRIPTION
ee5fa78d5672a2752da5937c5e6044e6b3e5ce98
### update local storage to not rely on widget count
this was creating all sorts of bugs when you remove items. the count is now unique so no two widgets ever can share the same local storage values.

211d289bc9297c988947f8f7f9aab01a0054998f
### only show default fields on load 
some times when I was on the equipment tests page the fields would show like Todd explained in #142. It seemed like a race condition with bootstrap/jquery or something and the toggleFields method in the settimeout. Anyway setting the fields to be visibly correct for the first load seems to fix that.

6b1cb663e92e1d2e2f27fc780171113d0a0ae798
### refactor for prepopulation

This takes the last value from the method cache id and uses it's value if it exists. 

closes #66 
closes #142