### PR TITLE
ci: switch to more reliable wait on

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
           start: npm start
           install-command: npm ci
           browser: chrome
-          wait-on: 'http://127.0.0.1:4000, http://localhost:5173'
+          wait-on: 'http://127.0.0.1:4000, http://127.0.0.1:5173'
           wait-on-timeout: 120
 
       - name: Upload Cypress Screenshots

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 💾 Cache firebase emulators
         uses: actions/cache@v3
         with:
-          path: ~/.cache/firebase/emulators
+          path: /home/runner/.cache/firebase/emulators
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('emulator-cache/**') }}
         continue-on-error: true
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,7 @@ export default defineConfig({
     })}'`,
     'process.env.VITE_BUILD': '"test"',
   },
+  server: {
+    host: true,
+  },
 });


### PR DESCRIPTION
https://github.com/cypress-io/github-action/tree/v6/#wait-on-with-nodejs-18